### PR TITLE
Correct deployment script for Lucee/MySQL

### DIFF
--- a/core/setup/inc/doa/DBmysql_lucee.cfc
+++ b/core/setup/inc/doa/DBmysql_lucee.cfc
@@ -17,7 +17,7 @@
 			var sErr = "";
 			var sDSNServer = "jdbc:mysql://#Arguments.DatabaseServer#:#Arguments.DatabasePort#/";  //build server part of jdbc string
 			var stcA2 = StructNew();
-			var sClass = "org.gjt.mm.mysql.Driver"; //this is the driver bundled with Railo
+			var sClass = "com.mysql.cj.jdbc.Driver"; //this is the driver bundled with Railo
 			var sDSNPara ="";
 			var sDSN=""; //empty to start
 			//example


### PR DESCRIPTION
Lucee updated the MySQL driver that was included with the server quite a while ago.  Uses the new 'com.mysql.cj.jdbc.Driver' package.  Minor update so that "Create Datasource/Database" script does not fail when trying to deploy without a DSN already created.